### PR TITLE
Optimize the json_command api.

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1179,6 +1179,7 @@ def json_command(cluster, target=('mon', ''), prefix=None, argdict=None,
     """
     cmddict = {}
     if prefix:
+        prefix = ' '.join(str(prefix).strip().split())
         cmddict.update({'prefix': prefix})
     if argdict:
         cmddict.update(argdict)


### PR DESCRIPTION
In json_command api, the prefix like 'osd tree' is ok, but 'osd    tree' or '   osd tree' will fail.
